### PR TITLE
Fix hotfix version numbering to Major.Minor.Patch format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,13 +33,15 @@ jobs:
           CURRENT_TAG=$VERSION
           MAJOR=$(echo $CURRENT_TAG | cut -d'.' -f1 | sed 's/v//')
           MINOR=$(echo $CURRENT_TAG | cut -d'.' -f2)
+          PATCH=$(echo $CURRENT_TAG | cut -d'.' -f3)
 
           # Increment the minor version and check if the tag exists
           NEW_MINOR=$((MINOR+1))
-          NEW_TAG="v$MAJOR.$NEW_MINOR"
+          NEW_TAG="v$MAJOR.$NEW_MINOR.$PATCH"
           while git rev-parse "$NEW_TAG" >/dev/null 2>&1; do
             NEW_MINOR=$((NEW_MINOR+1))
-            NEW_TAG="v$MAJOR.$NEW_MINOR"
+            NEW_TAG="v$MAJOR.$NEW_MINOR.$PATCH" 
+
           done
 
           # Output the new tag


### PR DESCRIPTION
## Description

This pull request fixes the issue with the version numbering format. Previously, the version numbering was in the format Major.Minor, but it has been adjusted to Major.Minor.Patch format. The commit "small adjustment to Increment Minor Version Tag step in the get_version job" ensures that the Patch number is included in the new version tag. This change ensures consistency and clarity in version numbering.

### Issues # (issue-id)
fixes #123

### Additional comments

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements (linting, refactoring, etc.)
- [ ] Other (please specify):

## Checklist

- [ ] My code follows the style guidelines of this project (ESLint, GoLint, etc.).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have run relevant linters (ESLint, GoLint, Qodana, etc.) and ensured that no new issues were introduced.
