### PR TITLE
Fix search functionality and logout API call

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,8 @@ import {
 } from "./helpers/cookieHelpers";
 import Weather from "./views/Weather";
 import Register from "./views/Register";
-import { Toaster } from "react-hot-toast";
+import toast, { Toaster } from "react-hot-toast";
+import { apiGetVoid } from "./utils/apiUtils";
 
 function App() {
   const [loggedIn, setLoggedIn] = useState<boolean>(false);
@@ -28,7 +29,9 @@ function App() {
 
   function logOut() {
     setLoggedIn(false);
-    removeJWTTokenFromCookies();
+    void apiGetVoid("/logout", true)
+      .catch((e) => toast.error(e.message))
+      .finally(() => removeJWTTokenFromCookies());
   }
 
   function logIn(jwt_token: string) {

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,17 +1,15 @@
 import { SpinnerInfinity } from "spinners-react";
 
-// This gives a "defaultProps will be removed..." warning,
-// This is a known issue with spinners-react, and it is not a problem.
-// The warning can be ignored.
-function LoadingSpinner({
-  size,
-  thickness,
-  speed
-}: {
+interface LoadingSpinnerProps {
   size?: number;
   thickness?: number;
   speed?: number;
-}) {
+}
+
+// This gives a "defaultProps will be removed..." warning,
+// This is a known issue with spinners-react, and it is not a problem.
+// The warning can be ignored.
+function LoadingSpinner({ size, thickness, speed }: Readonly<LoadingSpinnerProps>) {
   return (
     <SpinnerInfinity
       size={size}

--- a/frontend/src/utils/apiUtils.ts
+++ b/frontend/src/utils/apiUtils.ts
@@ -19,6 +19,12 @@ export async function apiGet<TResBody>(url: string, requireAuth?: boolean): Prom
   return await res.json();
 }
 
+/**
+ * Sends a GET request to the API, url is the path to the endpoint and should start with a /.
+ * This function does not expect a response body, but will not fail if there is one.
+ *
+ * Example: apiGetVoid("/logout", true) will send a GET request to /api/logout with the Authorization header set.
+ */
 export async function apiGetVoid(url: string, requireAuth?: boolean): Promise<void> {
   const res = await fetch(apiUrl + url, {
     headers: {

--- a/frontend/src/utils/apiUtils.ts
+++ b/frontend/src/utils/apiUtils.ts
@@ -19,6 +19,17 @@ export async function apiGet<TResBody>(url: string, requireAuth?: boolean): Prom
   return await res.json();
 }
 
+export async function apiGetVoid(url: string, requireAuth?: boolean): Promise<void> {
+  const res = await fetch(apiUrl + url, {
+    headers: {
+      Authorization: requireAuth ? `Bearer ${getJWTTokenFromCookies()}` : ""
+    }
+  });
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
+}
+
 /**
  * Sends a POST request to the API, url is the path to the endpoint and should start with a /.
  *

--- a/frontend/src/views/Search.tsx
+++ b/frontend/src/views/Search.tsx
@@ -12,6 +12,11 @@ function Search() {
 
   const handleSearch = () => {
     setLoading(true);
+    if (search.trim() === "") {
+      setSearchResponse(null);
+      setLoading(false);
+      return;
+    }
     apiGet<ISearchResponse>("/search?q=" + search)
       .then((response) => {
         setSearchResponse(response);
@@ -45,6 +50,11 @@ function Search() {
         {loading && (
           <div className="mt-32 w-full flex justify-center">
             <LoadingSpinner size={100} />
+          </div>
+        )}
+        {searchResponse === null && !loading && (
+          <div className="mt-4 italic text-gray-400 text-center text-lg">
+            Search for something...
           </div>
         )}
         {searchResponse?.data && searchResponse.data.length > 0 && (


### PR DESCRIPTION
## Description

This pull request fixes the following issues:

Closes #130: Fixed the "bad request" error that occurs when searching with an empty string. Now, when the search field is empty, the search is cleared and nothing is displayed, similar to when initially entering the search page.

Closes #129: Addressed code smells identified by SonarCloud.

Closes #128: Made the frontend call the /api/logout route when logging out. Previously, only the token was removed from cookies in the frontend. Now, a GET request is sent to /api/logout with the token in the header upon logout.

Additionally, the following changes were made:

- Made the props for the LoadingSpinner component readonly.

- Added documentation for the new function apiGetVoid.

### Issues # (issue-id)
#128, #129, #130

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code quality improvements (linting, refactoring, etc.)
- [ ] Other (please specify):

## Checklist

- [x] My code follows the style guidelines of this project (ESLint, GoLint, etc.).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have run relevant linters (ESLint, GoLint, Qodana, etc.) and ensured that no new issues were introduced.

