### PR TITLE
Add metrics registration and exposure in server startup

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -91,6 +91,9 @@ func startServer() {
 		"port": serverPort,
 	})
 
+	utils.RegisterMetrics()
+    utils.ExposeMetrics()
+
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", serverPort),
 		Handler:      api.NewRouter(),


### PR DESCRIPTION
 ## Description

Backend metrics defined in the prometheus.go utility are now registered and exposed during the server startup process. This change ensures that the metrics are available for monitoring.

### Issues # (issue-id)

Fixes #250

### Additional comments
none

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements (linting, refactoring, etc.)
- [ ] Other (please specify):

## Checklist

- [ ] My code follows the style guidelines of this project (ESLint, GoLint, etc.).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have run relevant linters (ESLint, GoLint, Qodana, etc.) and ensured that no new issues were introduced.

