### PR TITLE
#250 Expose backend metrics in server startup

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -9,10 +9,10 @@ import (
 	"github.com/CEM-KEA/whoknows/backend/internal/config"
 	"github.com/CEM-KEA/whoknows/backend/internal/utils"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	httpSwagger "github.com/swaggo/http-swagger"
 )
-
 
 // NewRouter initializes and returns a new HTTP router with all the necessary routes and middlewares configured.
 // It sets up static file routes, redirects, Swagger documentation, and API routes.
@@ -113,6 +113,7 @@ func setupAPIRoutes(router *mux.Router) {
 	router.HandleFunc("/api/logout", handlers.LogoutHandler).Methods("GET")
 	router.HandleFunc("/api/validate-login", handlers.ValidateLoginHandler).Methods("GET")
 	router.HandleFunc("/api/change-password", handlers.ChangePasswordHandler).Methods("POST")
+	router.Handle("/api/probe", promhttp.Handler())
 }
 
 

--- a/backend/internal/utils/prometheus.go
+++ b/backend/internal/utils/prometheus.go
@@ -1,10 +1,7 @@
 package utils
 
 import (
-	"net/http"
-
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -104,21 +101,20 @@ var (
 	)
 )
 
-
 // RegisterMetrics registers various Prometheus metrics used for monitoring
 // the application. It logs the start and successful completion of the
 // registration process. The metrics registered include:
-//  - HttpRequestsTotal: Total number of HTTP requests
-//  - HttpRequestDuration: Duration of HTTP requests
-//  - HttpActiveRequests: Number of active HTTP requests
-//  - HttpRequestSize: Size of HTTP requests
-//  - HttpResponseSize: Size of HTTP responses
-//  - DBQueryDuration: Duration of database queries
-//  - DBFailedQueries: Number of failed database queries
-//  - CacheHits: Number of cache hits
-//  - CacheMisses: Number of cache misses
-//  - UserRegistrations: Number of user registrations
-//  - SearchQueries: Number of search queries
+//   - HttpRequestsTotal: Total number of HTTP requests
+//   - HttpRequestDuration: Duration of HTTP requests
+//   - HttpActiveRequests: Number of active HTTP requests
+//   - HttpRequestSize: Size of HTTP requests
+//   - HttpResponseSize: Size of HTTP responses
+//   - DBQueryDuration: Duration of database queries
+//   - DBFailedQueries: Number of failed database queries
+//   - CacheHits: Number of cache hits
+//   - CacheMisses: Number of cache misses
+//   - UserRegistrations: Number of user registrations
+//   - SearchQueries: Number of search queries
 func RegisterMetrics() {
 	LogInfo("Registering Prometheus metrics", nil)
 	prometheus.MustRegister(HttpRequestsTotal)
@@ -139,12 +135,6 @@ func RegisterMetrics() {
 // and starts a server on port 9090 to expose these metrics. If the server fails to start,
 // an error is logged. A log message is also generated when the server starts successfully.
 func ExposeMetrics() {
-	http.Handle("/api/probe", promhttp.Handler())
-	go func() {
-		if err := http.ListenAndServe(":9090", nil); err != nil {
-			LogError(err, "Failed to start Prometheus metrics server", nil)
-		}
-	}()
 	LogInfo("Prometheus metrics server started on port 9090", nil)
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -91,6 +91,9 @@ func startServer() {
 		"port": serverPort,
 	})
 
+	utils.RegisterMetrics()
+    utils.ExposeMetrics()
+
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", serverPort),
 		Handler:      api.NewRouter(),


### PR DESCRIPTION

## Description

Metrics registration and exposure have been added to the server startup process. A new Prometheus metrics endpoint has been integrated into the router, ensuring that backend metrics are now available for monitoring. Cleanup of the metrics registration in the Prometheus utility has also been performed.

### Issues # (issue-id)
Fixes #250

### Additional comments
For some reason we had two separate server, now they are consolidated in one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvements (linting, refactoring, etc.)
- [ ] Other (please specify):

## Checklist

- [ ] My code follows the style guidelines of this project (ESLint, GoLint, etc.).
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have run relevant linters (ESLint, GoLint, Qodana, etc.) and ensured that no new issues were introduced.

