### PR TITLE
#250 Add metrics endpoint to API router

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -114,6 +114,7 @@ func setupAPIRoutes(router *mux.Router) {
 	router.HandleFunc("/api/validate-login", handlers.ValidateLoginHandler).Methods("GET")
 	router.HandleFunc("/api/change-password", handlers.ChangePasswordHandler).Methods("POST")
 	router.Handle("/api/probe", promhttp.Handler())
+	router.Handle("/metrics", promhttp.Handler())
 }
 
 


### PR DESCRIPTION
Expose backend metrics by adding a metrics endpoint to the API router. This change allows the monitoring system to access the backend metrics defined in the prometheus.go utility.

Fixes #250